### PR TITLE
improve fixture filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function(pathname) {
     .basename(pathname)
     .split('.')
     .reverse();
-  const fileName = fileNameParts.join('.');
+  const fileName = fileNameParts.reverse().join('.');
 
   // For cleaning, to store the test names that are active per file
   let testNames = [];

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const path = require('path');
 const util = require('./util');
 
 const guidGenerator = util.guidGenerator;
@@ -21,7 +22,11 @@ before(function() {
 });
 
 module.exports = function(pathname) {
-  const fileName = pathname.split('/')[pathname.split('/').length - 1].split('.')[0];
+  const [extName, ...fileNameParts] = path
+    .basename(pathname)
+    .split('.')
+    .reverse();
+  const fileName = fileNameParts.join('.');
 
   // For cleaning, to store the test names that are active per file
   let testNames = [];


### PR DESCRIPTION
Hi @Nanciee Thanks for this great plugin! 

I'm using this plugin in our project, one small issue I have is the fixture name. Currently, the filename of the fixture only grabs the first part from the filename. E.g., `/User/someone/test.js` will become `test`. This works for most of the case, but if the filename is something like `/User/someone/test.spec.js`, then the filename will still be `test`.

In our cases we have nested tests files, and some tests may start with the same name. E.g. `sorting.new.spec.js` and `sorting.old.spec.js`. In this case if I run the tests, one of them will override each other.

To make the plugin to handle this case, I've introduce the propose in this pull request. By extracting the  filename only removing the extension instead of just grabbing the first part.

With this change, the file name for the fixture will be:
* `/User/someone/test.js` will still be `test`
* `/User/someone/test.spec.js` will be `test.spec`
* `/User/someone/test.new.spec.js` will be `test.new.spec`

Please let me know what you think of this change, thanks!
