### PR TITLE
extract filename and paths from cypress api, support HEAD and headers, provide typescript typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To allow for auto-recording and stubbing to work, require cypress-autorecord in 
 const autoRecord = require('cypress-autorecord'); // Require the autorecord function
   
 describe('Home Page', function() { // Do not use arrow functions
-  autoRecord(__filename); // Call the autoRecord function at the beginning of your describe block and pass in `__filename`, other values will not work at this point
+  autoRecord(); // Call the autoRecord function at the beginning of your describe block
   
   // Your hooks (beforeEach, afterEach, etc) goes here
   
@@ -47,7 +47,7 @@ In the case you need to update your mocks for a particular test:
 const autoRecord = require('cypress-autorecord');
   
 describe('Home Page', function() {
-  autoRecord(__filename);
+  autoRecord();
   
   it('[r] my awesome test', function() { // Insert [r] at the beginning of your test name
     // ...

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare function autoRecord(): void;
+
+export = autoRecord;

--- a/index.js
+++ b/index.js
@@ -21,12 +21,11 @@ before(function() {
   }
 });
 
-module.exports = function(pathname) {
-  const [extName, ...fileNameParts] = path
-    .basename(pathname)
-    .split('.')
-    .reverse();
-  const fileName = fileNameParts.reverse().join('.');
+module.exports = function autoRecord() {
+  const fileName = path.basename(
+    Cypress.spec.name,
+    path.extname(Cypress.spec.name),
+  );
 
   // For cleaning, to store the test names that are active per file
   let testNames = [];

--- a/index.js
+++ b/index.js
@@ -97,11 +97,20 @@ module.exports = function(pathname) {
       });
 
       routesByTestId[this.currentTest.title].forEach((request) => {
-        if (!sortedRoutes[request.url]) {
-          sortedRoutes[request.url] = [];
-        }
+        if (request.body) {
+          if (!sortedRoutes[request.url]) {
+            sortedRoutes[request.url] = [];
+          }
 
-        sortedRoutes[request.url].push(request);
+          sortedRoutes[request.url].push(request);
+        } else {
+          cy.route({
+            method: request.method,
+            url: request.url,
+            status: request.status,
+            response: request.fixtureId ? `fixture:${request.fixtureId}.json` : request.response,
+          });
+        }
       });
 
       // This handles requests from the same url but with different request bodies
@@ -140,11 +149,6 @@ module.exports = function(pathname) {
 
       cy.route({
         method: 'DELETE',
-        url: '*',
-      });
-
-      cy.route({
-        method: 'PATCH',
         url: '*',
       });
     }

--- a/index.js
+++ b/index.js
@@ -151,6 +151,11 @@ module.exports = function(pathname) {
         method: 'DELETE',
         url: '*',
       });
+
+      cy.route({
+        method: 'PATCH',
+        url: '*',
+      });
     }
 
     // Store test name if isCleanMocks is true

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.13",
   "description": "It simplifies mocking by auto-recording/stubbing HTTP interactions and automate the process of updating/deleting recordings.",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/plugin.js
+++ b/plugin.js
@@ -1,6 +1,10 @@
+const path = require('path');
+
 module.exports = (on, config, fs) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+  const mocksFolder = path.resolve(config.fixturesFolder, '../mocks');
+
   const readFile = (filePath) => {
     if (fs.existsSync(filePath)) {
       return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -20,38 +24,38 @@ module.exports = (on, config, fs) => {
 
   const cleanMocks = () => {
     // TODO: create error handling
-    const specFiles = fs.readdirSync('cypress/integration');
-    const mockFiles = fs.readdirSync('cypress/mocks');
+    const specFiles = fs.readdirSync(config.integrationFolder);
+    const mockFiles = fs.readdirSync(mocksFolder);
     mockFiles.forEach(mockName => {
       const isMockUsed = specFiles.find(specName => specName.split('.')[0] === mockName.split('.')[0]);
-    if (!isMockUsed) {
-      const mockData = readFile(`cypress/mocks/${mockName}`);
-      Object.keys(mockData).forEach(testName => {
-        mockData[testName].forEach((route) => {
-          if (route.fixtureId) {
-            deleteFile(`cypress/fixtures/${route.fixtureId}.json`);
-          }
-      });
-    });
+      if (!isMockUsed) {
+        const mockData = readFile(path.join(mocksFolder, mockName));
+        Object.keys(mockData).forEach(testName => {
+          mockData[testName].forEach((route) => {
+            if (route.fixtureId) {
+              deleteFile(path.join(config.fixturesFolder, `${route.fixtureId}.json`));
+            }
+          });
+        });
 
-      deleteFile(`cypress/mocks/${mockName}`);
-    }
-  });
+        deleteFile(path.join(mocksFolder, mockName));
+      }
+    });
 
     return null;
   };
 
   const removeAllMocks = () => {
-    const fixtureFiles = fs.readdirSync('cypress/fixtures');
-    const mockFiles = fs.readdirSync('cypress/mocks');
+    const fixtureFiles = fs.readdirSync(config.fixturesFolder);
+    const mockFiles = fs.readdirSync(mocksFolder);
 
     fixtureFiles.forEach(fileName => {
-      deleteFile(`cypress/fixtures/${fileName}`);
-  });
+      deleteFile(path.join(config.fixturesFolder, fileName));
+    });
 
     mockFiles.forEach(fileName => {
-      deleteFile(`cypress/mocks/${fileName}`);
-  });
+      deleteFile(path.join(mocksFolder, fileName));
+    });
 
     return null;
   };


### PR DESCRIPTION
Thanks for this awesome plugin, Nancy! 

- I added support for HEAD requests and for storing a set of whitelisted headers (as regular expressions) that can be specified in `cypress.json`:

```
{
  "autorecord": {
     "whitelistHeaders": ["cache-control", "x-.*"]
  }
}
```
- Pull request #12 does break the plugin. I reverted the sorted change and re-applied the `PATCH` method handler.
- Using `__filename` yields the same result regardless of spec file name when there's a preprocessor step bundling before test execution. By using the cypress api directly (https://docs.cypress.io/api/cypress-api/spec.html#Syntax), we can get the actual file name regardless of whether the test content is bundled or not. It's also more convenient than passing `__filename` every time 😉.
- Using `fixturesFolder` and `integrationFolder` from Cypress configuration (https://docs.cypress.io/guides/references/configuration.html#Options) instead of hard coded paths and deriving mocks folder from `integrationFolder` (sibling). Projects using Nrwl's Nx tools, for example, have a slightly different directory structure and using hard coded paths puts the mocks in the wrong place.
- Provided an `index.d.ts` to remove typescript compiler complaints. 