### PR TITLE
fix: do not rerecord duplicate http requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,10 @@ module.exports = function autoRecord() {
           .reduce((obj, [key, value]) => ({...obj, [key]: value}), {});
 
         // We push a new entry into the routes array
-        routes.push({ url, method, status, data, body, headers });
+        // Do not rerecord duplicate requests
+        if(!routes.some(route => route.url === url && route.body === body && route.method === method)) {
+          routes.push({ url, method, status, data, body, headers });
+        }
       },
       // Disable all routes that are not mocked
       force404: true,


### PR DESCRIPTION
### Purpose
If an application makes duplicate http requests the recorder will log both instances. This will result in nasty cypress error because it is stubbing two routes with the same signature. See error below.
![image](https://user-images.githubusercontent.com/3660667/61654745-f5679900-ac71-11e9-9b96-5d7d91c3937d.png)

### Changes
Added to check to only record if the request coming in doesn't have a matching URL, METHOD, and BODY. This will remove the cypress error mentioned above