### PR TITLE
Feature: Organize fixtures by specs

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ module.exports = function autoRecord() {
       // Construct endpoint to be saved locally
       const endpoints = routes.map((request) => {
         // Check to see of mock data is too large for request header
-        const isFileOversized = sizeInMbytes(request.data) > 20;
+        const isFileOversized = sizeInMbytes(request.data) > 70;
         let fixtureId;
 
         // If the mock data is too large, store it in a separate json

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const fileName = path.basename(
 );
 // The replace fixes Windows path handling
 const fixturesFolder = Cypress.config('fixturesFolder').replace(/\\/g, '/');
+const fixturesFolderSubDirectory = fileName.replace(/\./, '-')
 const mocksFolder = path.join(fixturesFolder, '../mocks');
 
 before(function() {
@@ -129,7 +130,7 @@ module.exports = function autoRecord() {
             url: url,
             status: response.status,
             headers: response.headers,
-            response: response.fixtureId ? `fixture:${response.fixtureId}.json` : response.response,
+            response: response.fixtureId ? `fixture:${fixturesFolderSubDirectory}/${response.fixtureId}.json` : response.response,
             // This handles requests from the same url but with different request bodies
             onResponse: () => onResponse(method, url, index + 1),
           });
@@ -170,13 +171,13 @@ module.exports = function autoRecord() {
       // Construct endpoint to be saved locally
       const endpoints = routes.map((request) => {
         // Check to see of mock data is too large for request header
-        const isFileOversized = sizeInMbytes(request.data) > 70;
+        const isFileOversized = sizeInMbytes(request.data) > 20;
         let fixtureId;
 
         // If the mock data is too large, store it in a separate json
         if (isFileOversized) {
           fixtureId = guidGenerator();
-          addFixture[path.join(fixturesFolder, `${fixtureId}.json`)] = request.data;
+          addFixture[path.join(fixturesFolder, fixturesFolderSubDirectory, `${fixtureId}.json`)] = request.data;
         }
 
         return {
@@ -195,7 +196,7 @@ module.exports = function autoRecord() {
         routesByTestId[this.currentTest.title].forEach((route) => {
           // If fixtureId exist, delete the json
           if (route.fixtureId) {
-            removeFixture.push(path.join(fixturesFolder, `${route.fixtureId}.json`));
+            removeFixture.push(path.join(fixturesFolder, fixturesFolderSubDirectory, `${route.fixtureId}.json`));
           }
         });
       }
@@ -216,7 +217,7 @@ module.exports = function autoRecord() {
         } else {
           routesByTestId[testName].forEach((route) => {
             if (route.fixtureId) {
-              cy.task('deleteFile', path.join(fixturesFolder, `${route.fixtureId}.json`));
+              cy.task('deleteFile', path.join(fixturesFolder, fixturesFolderSubDirectory, `${route.fixtureId}.json`));
             }
           });
         }


### PR DESCRIPTION
### Purpose
When projects have a fair amount of specs with large recordings the fixtures folder becomes the dumping ground of cryptic json files with no organization.

<img width="376" alt="Screen Shot 2019-07-30 at 8 27 16 PM" src="https://user-images.githubusercontent.com/3660667/62183382-c656c480-b30e-11e9-8cae-c173b53bce19.png">

This PR seeks to organize the chaos and utilize the spec name to group them into folders
<img width="372" alt="Screen Shot 2019-07-30 at 9 05 10 PM" src="https://user-images.githubusercontent.com/3660667/62183400-dd95b200-b30e-11e9-9546-e8631f70c4d6.png">

This helps in a couple ways:
- organizes fixtures so you know which fixtures belong to which specs
- you can now easily delete fixtures vs looking at the `xx.xx.json` and searching for the filename by the ID

Please note that this is a **breaking change** since it changes where fixtures are looked up and saved to. Any recordings prior to this change will not work!