### PR TITLE
Some useful enhancements others may find valuable

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,11 +14,12 @@ const whitelistHeaders = cypressConfig.whitelistHeaders || [];
 const supportedMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD'];
 
 const fileName = path.basename(
-  Cypress.spec.name,
-  path.extname(Cypress.spec.name),
+    Cypress.spec.name,
+    path.extname(Cypress.spec.name),
 );
 // The replace fixes Windows path handling
 const fixturesFolder = Cypress.config('fixturesFolder').replace(/\\/g, '/');
+const fixturesFolderSubDirectory = fileName.replace(/\./, '-');
 const mocksFolder = path.join(fixturesFolder, '../mocks');
 
 before(function() {
@@ -32,26 +33,28 @@ before(function() {
 });
 
 module.exports = function autoRecord() {
-  const whitelistHeaderRegexes = whitelistHeaders.map(str => RegExp(str));
+  const whitelistHeaderRegexes = whitelistHeaders.map((str) => RegExp(str));
 
   // For cleaning, to store the test names that are active per file
-  let testNames = [];
+  const testNames = [];
   // For cleaning, to store the clean mocks per file
-  let cleanMockData = {};
+  const cleanMockData = {};
   // Locally stores all mock data for this spec file
   let routesByTestId = {};
   // For recording, stores data recorded from hitting the real endpoints
   let routes = [];
   // Stores any fixtures that need to be added
-  let addFixture = {};
+  const addFixture = {};
   // Stores any fixtures that need to be removed
-  let removeFixture = [];
+  const removeFixture = [];
   // For force recording, check to see if [r] is present in the test title
   let isTestForceRecord = false;
+  // Timestamp for when this test was executed
+  let timestamp = null;
 
   before(function() {
     // Get mock data that relates to this spec file
-    cy.task('readFile', path.join(mocksFolder, `${fileName}.json`)).then(data => {
+    cy.task('readFile', path.join(mocksFolder, `${fileName}.json`)).then((data) => {
       routesByTestId = data === null ? {} : data;
     });
   });
@@ -62,31 +65,42 @@ module.exports = function autoRecord() {
 
     cy.server({
       // Filter out blacklisted routes from being recorded and logged
-      whitelist: xhr => {
-        if(xhr.url) {
+      whitelist: (xhr) => {
+        if (xhr.url) {
           // TODO: Use blobs
-          return blacklistRoutes.some(route => xhr.url.includes(route));
+          return blacklistRoutes.some((route) => xhr.url.includes(route));
         }
       },
       // Here we handle all requests passing through Cypress' server
-      onResponse: response => {
+      onResponse: (response) => {
         const url = response.url;
         const status = response.status;
         const method = response.method;
         const data = response.response.body;
         const body = response.request.body;
         const headers = Object.entries(response.response.headers)
-          .filter(([key]) => whitelistHeaderRegexes.some(regex => regex.test(key)))
-          .reduce((obj, [key, value]) => ({...obj, [key]: value}), {});
+            .filter(([key]) => whitelistHeaderRegexes.some((regex) => regex.test(key)))
+            .reduce((obj, [key, value]) => ({ ...obj, [key]: value }), {});
 
         // We push a new entry into the routes array
         // Do not rerecord duplicate requests
-        if(!routes.some(route => route.url === url && route.body === body && route.method === method)) {
+        if (
+          !routes.some(
+              (route) =>
+                route.url === url &&
+              route.body === body &&
+              route.method === method &&
+              // when the response has changed for an identical request signature
+              // add this entry as well.  This is useful for polling-oriented endpoints
+              // that can have varying responses. 
+              route.response === data
+          )
+        ) {
           routes.push({ url, method, status, data, body, headers });
         }
       },
       // Disable all routes that are not mocked
-      force404: true,
+      force404: true
     });
 
     // check to see if test is being force recorded
@@ -105,15 +119,17 @@ module.exports = function autoRecord() {
     ) {
       // This is used to group routes by method type and url (e.g. { GET: { '/api/messages': {...} }})
       const sortedRoutes = {};
-      supportedMethods.forEach(method => {
+      supportedMethods.forEach((method) => {
         sortedRoutes[method] = {};
       });
 
+      // set the browser's Date to the timestamp at which this spec's endpoints were recorded.
+      cy.clock(routesByTestId[this.currentTest.title].timestamp, ['Date']);
       cy.server({
-        force404: true,
+        force404: true
       });
 
-      routesByTestId[this.currentTest.title].forEach((request) => {
+      routesByTestId[this.currentTest.title].routes.forEach((request) => {
         if (!sortedRoutes[request.method][request.url]) {
           sortedRoutes[request.method][request.url] = [];
         }
@@ -121,34 +137,56 @@ module.exports = function autoRecord() {
         sortedRoutes[request.method][request.url].push(request);
       });
 
-      const onResponse = (method, url, index) => {
-        if (sortedRoutes[method][url].length > index) {
-          const response = sortedRoutes[method][url][index];
-          cy.route({
-            method: response.method,
-            url: url,
-            status: response.status,
-            headers: response.headers,
-            response: response.fixtureId ? `fixture:${response.fixtureId}.json` : response.response,
-            // This handles requests from the same url but with different request bodies
-            onResponse: () => onResponse(method, url, index + 1),
-          });
-        }
+      const createStubbedRoute = (method, url) => {
+        let index = 0;
+        const response = sortedRoutes[method][url][index];
+        const onResponse = () => {
+          if (sortedRoutes[method][url].length > index + 1) {
+            index++;
+            const newResponse = sortedRoutes[method][url][index];
+            // `cy.now()` is an undocumented Cypress API that runs a command outside
+            //  of the normal execution chain:  https://docs.cypress.io/guides/guides/debugging.html#Run-Cypress-command-outside-the-test
+            // This fixes this known benign error: https://github.com/Nanciee/cypress-autorecord#uncaught-cypresserror-appears-for-certain-requests
+            cy.now('route', {
+              method: newResponse.method,
+              url: url,
+              status: newResponse.status,
+              headers: newResponse.headers,
+              response: newResponse.fixtureId ? `fixture:${fixturesFolderSubDirectory}/${newResponse.fixtureId}.json` : newResponse.response,
+              onResponse
+            });
+          }
+        };
+        cy.route({
+          method: response.method,
+          url: url,
+          status: response.status,
+          headers: response.headers,
+          response: response.fixtureId ? `fixture:${fixturesFolderSubDirectory}/${response.fixtureId}.json` : response.response,
+          // This handles requests from the same url but with different request bodies
+          onResponse
+        });
       };
 
       // Stub all recorded routes
-      Object.keys(sortedRoutes).forEach(method => {
-        Object.keys(sortedRoutes[method]).forEach(url => onResponse(method, url, 0))
+      Object.keys(sortedRoutes).forEach((method) => {
+        Object.keys(sortedRoutes[method]).forEach((url) => createStubbedRoute(method, url));
       });
     } else {
       // Allow all routes to go through
       cy.server({ force404: false });
 
+      // lock the browser's timestamp in place so that there is no variation with the
+      // timestamp REST APIs use as an argument due to undeterministic page load times
+      // which will cause varying timestamps.  `cy.clock` locks the timestamp.
+      timestamp = Date.now();
+      cy.clock(timestamp, ['Date']);
+
       // This tells Cypress to hook into all types of requests
-      supportedMethods.forEach(method => {
+      supportedMethods.forEach((method) => {
         cy.route({
           method,
-          url: '*',
+          url: '*'
         });
       });
     }
@@ -176,7 +214,7 @@ module.exports = function autoRecord() {
         // If the mock data is too large, store it in a separate json
         if (isFileOversized) {
           fixtureId = guidGenerator();
-          addFixture[path.join(fixturesFolder, `${fixtureId}.json`)] = request.data;
+          addFixture[path.join(fixturesFolder, fixturesFolderSubDirectory, `${fixtureId}.json`)] = request.data;
         }
 
         return {
@@ -186,23 +224,30 @@ module.exports = function autoRecord() {
           status: request.status,
           headers: request.headers,
           body: request.body,
-          response: isFileOversized ? undefined : request.data,
+          response: isFileOversized ? undefined : request.data
         };
       });
 
       // Delete fixtures if we are overwriting mock data
       if (routesByTestId[this.currentTest.title]) {
-        routesByTestId[this.currentTest.title].forEach((route) => {
+        routesByTestId[this.currentTest.title].routes.forEach((route) => {
           // If fixtureId exist, delete the json
           if (route.fixtureId) {
-            removeFixture.push(path.join(fixturesFolder, `${route.fixtureId}.json`));
+            removeFixture.push(path.join(fixturesFolder, fixturesFolderSubDirectory, `${route.fixtureId}.json`));
           }
         });
       }
 
       // Store the endpoint for this test in the mock data object for this file if there are endpoints for this test
       if (endpoints.length > 0) {
-        routesByTestId[this.currentTest.title] = endpoints;
+        routesByTestId[this.currentTest.title] = {
+          // since REST APIs can pass a timestamp argument, we need to keep track
+          // of the time at which this spec was recorded so we can set the browser's Date
+          // to that specific time so that the endpoints can be properly stubbed as the
+          // the timestamp is part of many of the APIs' signature as well as POST body and uniquely identifies it.
+          timestamp,
+          routes: endpoints
+        };
       }
     }
   });
@@ -214,18 +259,18 @@ module.exports = function autoRecord() {
         if (testNames.includes(testName)) {
           cleanMockData[testName] = routesByTestId[testName];
         } else {
-          routesByTestId[testName].forEach((route) => {
+          routesByTestId[testName].routes.forEach((route) => {
             if (route.fixtureId) {
-              cy.task('deleteFile', path.join(fixturesFolder, `${route.fixtureId}.json`));
+              cy.task('deleteFile', path.join(fixturesFolder, fixturesFolderSubDirectory, `${route.fixtureId}.json`));
             }
           });
         }
       });
     }
 
-    removeFixture.forEach(fixtureName => cy.task('deleteFile', fixtureName));
+    removeFixture.forEach((fixtureName) => cy.task('deleteFile', fixtureName));
     cy.writeFile(path.join(mocksFolder, `${fileName}.json`), isCleanMocks ? cleanMockData : routesByTestId);
-    Object.keys(addFixture).forEach(fixtureName => {
+    Object.keys(addFixture).forEach((fixtureName) => {
       cy.writeFile(fixtureName, addFixture[fixtureName]);
     });
   });

--- a/plugin.js
+++ b/plugin.js
@@ -26,11 +26,11 @@ module.exports = (on, config, fs) => {
     // TODO: create error handling
     const specFiles = fs.readdirSync(config.integrationFolder);
     const mockFiles = fs.readdirSync(mocksFolder);
-    mockFiles.forEach(mockName => {
-      const isMockUsed = specFiles.find(specName => specName.split('.')[0] === mockName.split('.')[0]);
+    mockFiles.forEach((mockName) => {
+      const isMockUsed = specFiles.find((specName) => specName.split('.')[0] === mockName.split('.')[0]);
       if (!isMockUsed) {
         const mockData = readFile(path.join(mocksFolder, mockName));
-        Object.keys(mockData).forEach(testName => {
+        Object.keys(mockData).forEach((testName) => {
           mockData[testName].forEach((route) => {
             if (route.fixtureId) {
               deleteFile(path.join(config.fixturesFolder, `${route.fixtureId}.json`));
@@ -49,11 +49,11 @@ module.exports = (on, config, fs) => {
     const fixtureFiles = fs.readdirSync(config.fixturesFolder);
     const mockFiles = fs.readdirSync(mocksFolder);
 
-    fixtureFiles.forEach(fileName => {
+    fixtureFiles.forEach((fileName) => {
       deleteFile(path.join(config.fixturesFolder, fileName));
     });
 
-    mockFiles.forEach(fileName => {
+    mockFiles.forEach((fileName) => {
       deleteFile(path.join(mocksFolder, fileName));
     });
 
@@ -64,6 +64,6 @@ module.exports = (on, config, fs) => {
     readFile,
     deleteFile,
     cleanMocks,
-    removeAllMocks,
+    removeAllMocks
   });
 };

--- a/util.js
+++ b/util.js
@@ -2,6 +2,7 @@ const sizeInMbytes = (obj) => {
   let bytes = 0;
 
   const sizeOf = (obj) => {
+    let objClass;
     if (obj !== null && obj !== undefined) {
       switch (typeof obj) {
         case 'number':
@@ -14,9 +15,9 @@ const sizeInMbytes = (obj) => {
           bytes += 4;
           break;
         case 'object':
-          var objClass = Object.prototype.toString.call(obj).slice(8, -1);
+          objClass = Object.prototype.toString.call(obj).slice(8, -1);
           if (objClass === 'Object' || objClass === 'Array') {
-            for (var key in obj) {
+            for (const key in obj) {
               if (!obj.hasOwnProperty(key)) continue;
               sizeOf(obj[key]);
             }
@@ -31,11 +32,11 @@ const sizeInMbytes = (obj) => {
 };
 
 const guidGenerator = () => {
-  const S4 = () => (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1);
-  return (S4() + S4() + S4() + S4() + S4() + S4() + S4() + S4());
+  const s4 = () => (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1);
+  return (s4() + s4() + s4() + s4() + s4() + s4() + s4() + s4());
 };
 
 module.exports = {
   sizeInMbytes,
-  guidGenerator,
+  guidGenerator
 };


### PR DESCRIPTION
Refer to comments in diff for more details.

- use `cy.now(...)` to insert new stubbed route
- organize fixtures by spec (credit: https://github.com/Nanciee/cypress-autorecord/pull/17)
- add timestamp to tests so browser is brought back to the time where the mocks live
- add new stub when response data changes