### PR TITLE
Handle blob response data

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const util = require('./util');
 
 const guidGenerator = util.guidGenerator;
 const sizeInMbytes = util.sizeInMbytes;
+const blobToPlain = util.blobToPlain;
 
 const cypressConfig = Cypress.config('autorecord') || {};
 const isCleanMocks = cypressConfig.cleanMocks || false;
@@ -76,7 +77,9 @@ module.exports = function autoRecord() {
         const url = response.url;
         const status = response.status;
         const method = response.method;
-        const data = response.response.body;
+        const data = response.response.body.constructor.name === 'Blob'
+            ? blobToPlain(response.response.body)
+            : response.response.body;
         const body = response.request.body;
         const headers = Object.entries(response.response.headers)
             .filter(([key]) => whitelistHeaderRegexes.some((regex) => regex.test(key)))

--- a/util.js
+++ b/util.js
@@ -36,7 +36,22 @@ const guidGenerator = () => {
   return (s4() + s4() + s4() + s4() + s4() + s4() + s4() + s4());
 };
 
+const blobToPlain = (blob) => {
+  let uri = URL.createObjectURL(blob);
+  let xhr = new XMLHttpRequest();
+
+  xhr.open('GET', uri, false);
+  xhr.send();
+
+  URL.revokeObjectURL(uri);
+
+  return blob.type === 'application/json'
+    ? JSON.parse(xhr.response)
+    : xhr.response;
+}
+
 module.exports = {
   sizeInMbytes,
-  guidGenerator
+  guidGenerator,
+  blobToPlain
 };


### PR DESCRIPTION
Uses a hacky way to convert blob responses to plain text (or objects when possible). Still need to find a cleaner solution using FileReader, but solves the problem for now.