### PR TITLE
Fix mock filename when running all specs

### DIFF
--- a/cypress/integration/fixture.spec.js
+++ b/cypress/integration/fixture.spec.js
@@ -27,7 +27,7 @@ describe('setup', function () {
     cy.readFile('../mocks/fixture.spec.json').should('not.exist');
     cy.readFile('../fixtures/fixture-spec').should('not.exist');
     // Ensure the http request has finished
-    cy.contains(/"userId":1/i);
+    cy.contains(/"id":1/i);
   });
 });
 

--- a/cypress/integration/index.html
+++ b/cypress/integration/index.html
@@ -6,15 +6,7 @@
     </div>
   </main>
   <script>
-    // var oReq = new XMLHttpRequest();
-    // oReq.addEventListener('load', function () {
-    //   var json = JSON.parse(this.responseText);
-    //   document.getElementById('json').innerText = JSON.stringify(json);
-    // });
-    // oReq.open('GET', 'https://jsonplaceholder.typicode.com/todos/1');
-    // oReq.send();
-
-    fetch('https://jsonplaceholder.typicode.com/todos/1')
+    fetch('https://reqres.in/api/users/1')
       .then((response) => response.json())
       .then((json) => {
         document.getElementById('json').innerText = JSON.stringify(json);

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -1,18 +1,29 @@
 const autoRecord = require('../../index');
 const testName = 'records a mock after the test has finished';
 
+// Ensures the next test doesn't load fixtures before they're
+// deleted!
+describe('beforeSetup', function () {
+  beforeEach(function () {
+    cy.task('removeAllMocks');
+  });
+
+  it('deletes the mocks', function () {
+    cy.readFile('../mocks/spec.json').should('not.exist');
+  });
+});
+
 describe('setup', function () {
   autoRecord();
 
   beforeEach(function () {
-    cy.task('removeAllMocks');
     cy.visit('cypress/integration/index.html');
   });
 
   it(testName, function () {
     cy.readFile('../mocks/spec.json').should('not.exist');
     // Ensure the http request has finished
-    cy.contains(/"userId":1/i);
+    cy.contains(/"id":1/i);
   });
 });
 
@@ -25,7 +36,7 @@ describe('test', function () {
         const { routes } = mock[testName];
         const [{ response }] = routes;
 
-        expect(response).to.include({ userId: 1, id: 1 });
+        expect(response.data).to.include({ id: 1 });
       });
     });
   });

--- a/index.js
+++ b/index.js
@@ -151,7 +151,6 @@ module.exports = function autoRecord() {
 
       const createStubbedRoute = (method, url) => {
         let index = 0;
-        const response = sortedRoutes[method][url][index];
 
         cy.intercept(
           {
@@ -159,22 +158,22 @@ module.exports = function autoRecord() {
             method,
           },
           (req) => {
-            req.reply((res) => {
-              const newResponse = sortedRoutes[method][url][index];
-              res.send(
-                newResponse.status,
-                newResponse.fixtureId
-                  ? {
-                      fixture: `${fixturesFolderSubDirectory}/${newResponse.fixtureId}.json`,
-                    }
-                  : newResponse.response,
-                newResponse.headers,
-              );
+            const newResponse = sortedRoutes[method][url][index];
 
-              if (sortedRoutes[method][url].length > index + 1) {
-                index++;
-              }
-            });
+            const response = {
+              statusCode: newResponse.status,
+              body: newResponse.response,
+              fixture: newResponse.fixtureId
+                ? `${fixturesFolderSubDirectory}/${newResponse.fixtureId}.json`
+                : undefined,
+              headers: newResponse.headers,
+            };
+
+            req.reply(response);
+
+            if (sortedRoutes[method][url].length > index + 1) {
+              index++;
+            }
           },
         );
       };

--- a/index.js
+++ b/index.js
@@ -26,13 +26,8 @@ const whitelistHeaders = cypressConfig.whitelistHeaders || [];
 const maxInlineResponseSize = cypressConfig.maxInlineResponseSize || 70;
 const supportedMethods = ['get', 'GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD'];
 
-const fileName = path.basename(
-    Cypress.spec.name,
-    path.extname(Cypress.spec.name),
-);
 // The replace fixes Windows path handling
 const fixturesFolder = Cypress.config('fixturesFolder').replace(/\\/g, '/');
-const fixturesFolderSubDirectory = fileName.replace(/\./, '-');
 const mocksFolder = path.join(fixturesFolder, '../mocks');
 
 before(function() {
@@ -67,12 +62,16 @@ module.exports = function autoRecord() {
 
   before(function() {
     // Get mock data that relates to this spec file
+    const fileName = getFileName(this.currentTest);
     cy.task('readFile', path.join(mocksFolder, `${fileName}.json`)).then((data) => {
       routesByTestId = data === null ? {} : data;
     });
   });
 
   beforeEach(function() {
+    const fileName = getFileName(this.currentTest);
+    const fixturesFolderSubDirectory = getFixturesSubFolder(fileName);
+
     // Reset routes before each test case
     routes = [];
 
@@ -86,13 +85,13 @@ module.exports = function autoRecord() {
 
       req.reply((res) => {
         const url = req.url;
-        const status = res.statusCode;
         const method = req.method;
+        const body = req.body;
+        const status = res.statusCode;
         const data =
           res.body.constructor.name === 'Blob'
             ? blobToPlain(res.body)
             : res.body;
-        const body = req.body;
         const headers = Object.entries(res.headers)
           .filter(([key]) =>
             whitelistHeaderRegexes.some((regex) => regex.test(key)),
@@ -199,6 +198,9 @@ module.exports = function autoRecord() {
   });
 
   afterEach(function() {
+    const fileName = getFileName(this.currentTest);
+    const fixturesFolderSubDirectory = getFixturesSubFolder(fileName);
+
     // Check to see if the current test already has mock data or if forceRecord is on
     if (
       (!routesByTestId[this.currentTest.title]
@@ -254,6 +256,9 @@ module.exports = function autoRecord() {
   });
 
   after(function() {
+    const fileName = getFileName(this.currentTest);
+    const fixturesFolderSubDirectory = getFixturesSubFolder(fileName);
+
     // Transfer used mock data to new object to be stored locally
     if (isCleanMocks) {
       Object.keys(routesByTestId).forEach((testName) => {
@@ -276,3 +281,14 @@ module.exports = function autoRecord() {
     });
   });
 };
+
+function getFileName(currentTest) {
+  return path.basename(
+    currentTest.invocationDetails.relativeFile,
+    path.extname(currentTest.invocationDetails.relativeFile),
+  );
+}
+
+function getFixturesSubFolder(mockFilename) {
+  return mockFilename.replace(/\./, '-');
+}


### PR DESCRIPTION
When running all specs, the mocks are recorded in a new file called "All Specs". This pull request attempts to find the filename based on the currentTest invocation details. AFAIK `currentTest.invocationDetails` is an undocumented api (Cypress adds it to mocha's Test instance). However this really helps when you want to run all specs on a CI server, but still maintain individual mock files.

Cypress v5.4.0