### PR TITLE
fix: restore the `clock` in `beforeEach`

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,6 +198,8 @@ module.exports = function autoRecord() {
     if (isCleanMocks) {
       testNames.push(this.currentTest.title);
     }
+
+    cy.clock().invoke('restore');
   });
 
   afterEach(function() {


### PR DESCRIPTION
When `clock` was mocked I wasn't able to `cy.visit` in my spec. [Restoring clock](https://docs.cypress.io/api/commands/clock#Restore-clock) allowed my spec to run.