### PR TITLE
use md5 hash as alias

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ module.exports = function autoRecord() {
             });
           }
         };
-        const alias = crypto.createHash('md5').update(url).digest("hex")
+        const alias = crypto.createHash('md5').update(url).digest('hex')
         cy.route({
           method: response.method,
           url: url,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const path = require('path');
+const crypto = require('crypto');
 const util = require('./util');
 
 const guidGenerator = util.guidGenerator;
@@ -160,6 +161,7 @@ module.exports = function autoRecord() {
             });
           }
         };
+        const alias = crypto.createHash('md5').update(url).digest("hex")
         cy.route({
           method: response.method,
           url: url,
@@ -168,7 +170,7 @@ module.exports = function autoRecord() {
           response: response.fixtureId ? `fixture:${fixturesFolderSubDirectory}/${response.fixtureId}.json` : response.response,
           // This handles requests from the same url but with different request bodies
           onResponse
-        });
+        }).as(alias);
       };
 
       // Stub all recorded routes


### PR DESCRIPTION
I had cases where I needed to `cy.wait` on certain responses.

This will create a md5 hash out of the `url` so we could `cy.wait(HASH_GOES_HERE)`.

![Screen Shot 2021-04-05 at 4 12 33 PM](https://user-images.githubusercontent.com/567126/113637805-57288c00-962a-11eb-955f-3b295bab59c3.png)
