### PR TITLE
fix response with fixtureId.

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,10 +163,11 @@ module.exports = function autoRecord() {
             let newResponse = response.response;
             if (response.fixtureId) {
               newResponse = {
-                fixture: `${fixturesFolderSubDirectory}/${response.fixtureId}.json`,
+                statusCode: response.status,
+                fixture: `${fixturesFolderSubDirectory}/${response.fixtureId}.json`
               };
             }
-            req.reply(response.status, newResponse, response.headers);
+            req.reply(newResponse, response.headers);
 
             if (sortedRoutes[method][url].length > index + 1) {
               index++;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-autorecord",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Cypress is returning the fixture file directory as string instead of fixture file content.
For more details, please check the issue: https://github.com/Nanciee/cypress-autorecord/issues/54