### PR TITLE
Enable regex support for interceptPattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,17 @@ const isCleanMocks = cypressConfig.cleanMocks || false;
 const isForceRecord = cypressConfig.forceRecord || false;
 const recordTests = cypressConfig.recordTests || [];
 const blacklistRoutes = cypressConfig.blacklistRoutes || [];
-const interceptPattern = cypressConfig.interceptPattern || "*";
+
+let interceptPattern = cypressConfig.interceptPattern || "*";
+const interceptPatternFragments =
+  interceptPattern.match(/\/(.*?)\/([a-z]*)?$/i);
+if (interceptPatternFragments) {
+  interceptPattern = new RegExp(
+    interceptPatternFragments[1],
+    interceptPatternFragments[2] || ""
+  );
+}
+
 const whitelistHeaders = cypressConfig.whitelistHeaders || [];
 const supportedMethods = [
   "get",

--- a/index.js
+++ b/index.js
@@ -173,10 +173,11 @@ module.exports = function autoRecord() {
             let newResponse = response.response;
             if (response.fixtureId) {
               newResponse = {
+                statusCode: response.status,
                 fixture: `${fixturesFolderSubDirectory}/${response.fixtureId}.json`,
               };
             }
-            req.reply(response.status, newResponse, response.headers);
+            req.reply(newResponse, response.headers);
 
             if (sortedRoutes[method][url].length > index + 1) {
               index++;


### PR DESCRIPTION
Fix for https://github.com/Nanciee/cypress-autorecord/issues/56

It will allow to do like this:
```
interceptPattern = new RegExp(REGEX_STRING).toString()
```