### PR TITLE
Raise Errors for Missing Routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ Alternatively, you can update recordings for all tests by setting `forceRecord` 
 }
 ```
 
+## Raising Errors for Missing Routes
+
+For some use-cases, you may want to be sure that other routes from your backend aren't being called when there is no recorded mock for them.
+In this case, you can raise an error for routes that match your intercept pattern for which there isn't a mock.
+This won't interfere if you have `recordTests` or `forceRecord` enabled for a test and will allow your mocks to update.
+
+Set `raiseMissingRouteErrors` to `true` in the file `cypress.json` and cypress-autorecord will raise an error for any route that doesn't have a mock (when it matches your intercept pattern):
+
+```json
+{
+  "autorecord": {
+    "raiseMissingRouteErrors": true
+  }
+}
+```
+
 ## Removing Stale Mocks
 
 Stale mocks that are no longer being used can be automatically removed when you run your tests by setting `cleanMocks` to `true` in the file `cypress.json`:

--- a/index.js
+++ b/index.js
@@ -96,6 +96,7 @@ module.exports = function autoRecord() {
       ) {
         const currentMock = routesByTestId[Cypress.currentTest.title]
         if (currentMock && currentMock.routes && currentMock.routes.length > 0) {
+          // Raise missing route error
           throw new Error(`No mock found for ${req.method} ${req.url}`)
         }
       }

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ module.exports = function autoRecord() {
       // so we throw an error
       if (!isForceRecord && raiseMissingRouteErrors) {
         const currentMock = routesByTestId[Cypress.currentTest.title]
-        if (currentMock && currentMock.routes?.length > 0) {
+        if (currentMock && currentMock.routes && currentMock.routes.length > 0) {
           throw new Error(`No mock found for ${req.method} ${req.url}`)
         }
       }

--- a/index.js
+++ b/index.js
@@ -89,7 +89,11 @@ module.exports = function autoRecord() {
       // and we have an existing mock recording for this test
       // then we are calling some route that matches the intercept pattern for which we have no mock
       // so we throw an error
-      if (!isForceRecord && raiseMissingRouteErrors) {
+      if (
+        raiseMissingRouteErrors &&
+        !isTestForceRecord &&
+        !recordTests.includes(Cypress.currentTest.title)
+      ) {
         const currentMock = routesByTestId[Cypress.currentTest.title]
         if (currentMock && currentMock.routes && currentMock.routes.length > 0) {
           throw new Error(`No mock found for ${req.method} ${req.url}`)

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const isCleanMocks = cypressConfig.cleanMocks || false;
 const isForceRecord = cypressConfig.forceRecord || false;
 const recordTests = cypressConfig.recordTests || [];
 const blacklistRoutes = cypressConfig.blacklistRoutes || [];
+const raiseMissingRouteErrors = cypressConfig.raiseMissingRouteErrors || false;
 
 let interceptPattern = cypressConfig.interceptPattern || '*';
 const interceptPatternFragments =
@@ -82,6 +83,17 @@ module.exports = function autoRecord() {
         Object.keys(req.headers).some((k) => k === 'x-cypress-authorization')
       ) {
         return;
+      }
+
+      // If raiseMissingRouteErrors is set and we're not force recording
+      // and we have an existing mock recording for this test
+      // then we are calling some route that matches the intercept pattern for which we have no mock
+      // so we throw an error
+      if (!isForceRecord && raiseMissingRouteErrors) {
+        const currentMock = routesByTestId[Cypress.currentTest.title]
+        if (currentMock && currentMock.routes?.length > 0) {
+          throw new Error(`No mock found for ${req.method} ${req.url}`)
+        }
       }
 
       req.reply((res) => {


### PR DESCRIPTION
## Overview

We are using `cypress-autorecord` to mock out our backend APIs in several React-only front-end apps deployed as static bundles that perform cross-origin API requests.

We want to fail a test if code calls one of our API endpoints that we don't expect (i.e. it matches the intercept pattern but it's not in the mock).

## Solution

- Add a `raiseMissingRouteErrors` configuration setting.
- When this is enabled, raise an error if:
  - We have an existing mock for the test.
  - This mock doesn't include the route we're fetching.
  - The route we're fetching matches the intercept pattern.
- Skip the above if the `isTestForceRecord` or `recordTests` flags are being used. Lets you update mocks easily by turning these on to add new routes if required.

@Nanciee let me know if you'd like to merge this in or whether we should look to maintain our own fork. I am also interested in adding an option to group mocks in folders to mirror the file structure of the tests, looks like [this one](https://github.com/Nanciee/cypress-autorecord/pull/29) was never merged but can do a version of this and open a subsequent PR if you'd appreciate more contributions 😎 